### PR TITLE
7 Fix button 'exescorm:editonlineandreturntocourse'

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -260,7 +260,7 @@ class mod_exeweb_mod_form extends moodleform_mod {
                     $returnto = new moodle_url("/mod/exeweb/view.php", ['id' => $data->coursemodule, 'forceview' => 1]);
                 } else {
                     // Return to course.
-                    $returnto = course_get_url($data->course, $data->coursesection ?? null, array('sr' => $data->sr));
+                    $returnto = course_get_url($data->course, null, array(''));
                 }
                 // Set this becouse modedit.php expects it.
                 $data->submitbutton = true;


### PR DESCRIPTION
Same as exescorm. 
** Now the JWT is correctly generated when we press "Edit on eXeLearning and return to course" button. **
[exescorm PR-29](https://github.com/exelearning/mod_exescorm/pull/29)

---
![image](https://github.com/user-attachments/assets/7b633ae2-1104-4435-8c20-4f622be09784)
