### PR TITLE
#10 - Hide edit with exe and added flexibility to check it when creating scorm when there's no exeonlinebaseuri setting

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -45,7 +45,8 @@ class renderer extends \plugin_renderer_base {
      */
     public function generate_action_bar(\stdClass $cm): string {
         $context = [];
-        if (has_capability('moodle/course:update', context_course::instance($cm->course))) {
+        $hascapability = has_capability('moodle/course:update', context_course::instance($cm->course));
+        if ($hascapability && get_config('exeweb', 'exeonlinebaseuri')) {
             $returnto = new moodle_url("/mod/exeweb/view.php", ['id' => $cm->id, 'forceview' => 1]);
             $context['editaction'] = exeonline_redirector::get_redirection_url($cm->id, $returnto)->out(false);
         }

--- a/mod_form.php
+++ b/mod_form.php
@@ -66,7 +66,7 @@ class mod_exeweb_mod_form extends moodleform_mod {
             EXEWEB_ORIGIN_LOCAL => get_string('typelocal', 'mod_exeweb'),
         ];
         $defaulttype = EXEWEB_ORIGIN_LOCAL;
-        if (!empty($config->exeonlinebaseuri) && !empty($config->hmackey1)) {
+        if (!empty($config->exeonlinebaseuri)) {
             if ($editmode) {
                 $exeorigins[EXEWEB_ORIGIN_EXEONLINE] = get_string('typeexewebedit', 'mod_exeweb');
             } else {


### PR DESCRIPTION
When there's no exeonlinebaseuri on settings:
* Hide 'Edit with eXeLearning' Button when visiting a exeweb activity
* Default 'Upoload Package' on Exeweb activity creation form
        