### PR TITLE
Fix #35 - Align "Create with eXeLearning" label with mod_exescorm

### DIFF
--- a/lang/en/exeweb.php
+++ b/lang/en/exeweb.php
@@ -133,7 +133,7 @@ $string['exeorigin_help'] = 'This setting determines how the package is included
 
 * Uploaded package - Enables a zipped eXeLearning website to be chosen via the file picker.
 * Create with eXeLearning (embedded editor) - Creates the activity using the embedded editor. You can then edit it directly from the activity view page.
-* Create/Edit with eXeLearning (Online) - Creates the activity and takes you to eXeLearning Online to edit the package. When done, eXeLearning will send the newly created package back to Moodle.';
+* Create/Edit with eXeLearning - Creates the activity and takes you to eXeLearning to edit the package. When done, eXeLearning will send the newly created package back to Moodle.';
 $string['exeweb:exportexeweb'] = 'Export';
 $string['exeweb:view'] = 'View';
 $string['search:activity'] = 'File';

--- a/lang/es/exeweb.php
+++ b/lang/es/exeweb.php
@@ -133,7 +133,7 @@ $string['exeorigin_help'] = 'Este ajuste determina cómo se incluye el paquete e
 
 * Paquete subido - Permite elegir el zip creado con eXeLearning por medio del selector de archivos.
 * Crear con eXeLearning (editor integrado) - Crea la actividad usando el editor integrado. Podrá editarla directamente desde la página de visualización de la actividad.
-* Crear/Editar con eXeLearning (Online) - Crea la actividad y te lleva a eXeLearning Online para editar el contenido. Al terminar, eXeLearning lo enviará de vuelta a Moodle.';
+* Crear/Editar con eXeLearning - Crea la actividad y te lleva a eXeLearning para editar el contenido. Al terminar, eXeLearning lo enviará de vuelta a Moodle.';
 $string['exeweb:exportexeweb'] = 'Exportar recurso';
 $string['exeweb:view'] = 'Ver recurso';
 $string['search:activity'] = 'Fichero';

--- a/mod_form.php
+++ b/mod_form.php
@@ -75,11 +75,9 @@ class mod_exeweb_mod_form extends moodleform_mod {
             }
         } else if (exeweb_online_editor_available()) {
             if ($editmode) {
-                $exeorigins[EXEWEB_ORIGIN_EXEONLINE] = get_string('typeexewebedit', 'mod_exeweb')
-                    . ' (Online)';
+                $exeorigins[EXEWEB_ORIGIN_EXEONLINE] = get_string('typeexewebedit', 'mod_exeweb');
             } else {
-                $exeorigins[EXEWEB_ORIGIN_EXEONLINE] = get_string('typeexewebcreate', 'mod_exeweb')
-                    . ' (Online)';
+                $exeorigins[EXEWEB_ORIGIN_EXEONLINE] = get_string('typeexewebcreate', 'mod_exeweb');
                 $defaulttype = EXEWEB_ORIGIN_EXEONLINE;
             }
         }


### PR DESCRIPTION
## Summary
- Removes the appended `" (Online)"` suffix from the activity type dropdown in `mod_form.php`, so the option reads `Create with eXeLearning` / `Crear con eXeLearning` — matching the wording used by `mod_exescorm`.
- Updates the `exeorigin_help` strings in `lang/en/exeweb.php` and `lang/es/exeweb.php` to drop the `(Online)` qualifier (the `ca`, `eu`, `gl` translations already used the unsuffixed form).

Closes #35.

## Why
Issue #35 reported a mismatch between the two plugins' configuration UIs:

- `mod_exescorm`: "Crear con eXeLearning"
- `mod_exeweb`: "Crear con eXeLearning (online)"

The `(Online)` was hard-coded as a string concatenation in `mod_form.php`, so it was not localized and produced a needless inconsistency between the two activity modules. With the embedded editor now being the default and "Online" being just one of the available editor modes, the qualifier in the dropdown label is redundant.

## Test plan
- [ ] In a Moodle site with `editormode = online`, add a new "eXeLearning (website)" activity → the type selector shows `Crear con eXeLearning` (no `(Online)` suffix) and matches the same option in `mod_exescorm`.
- [ ] Edit an existing online activity → the selector shows `Editar con eXeLearning` without the `(Online)` suffix.
- [ ] Switch the site language to English/Spanish and verify the help bubble for the `Type` field no longer mentions `(Online)`.
- [ ] With `editormode = embedded`, confirm the embedded option still reads `Create with eXeLearning (embedded editor)` (unchanged).

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgV2ViIERlbW8iLCJsb2NhbGUiOiJlcyIsInRpbWV6b25lIjoiRXVyb3BlL01hZHJpZCJ9fSx7InN0ZXAiOiJsb2dpbiIsInVzZXJuYW1lIjoie3tBRE1JTl9VU0VSfX0ifSx7InN0ZXAiOiJpbnN0YWxsTW9vZGxlUGx1Z2luIiwicGx1Z2luVHlwZSI6Im1vZCIsInBsdWdpbk5hbWUiOiJleGV3ZWIiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vZXhlbGVhcm5pbmcvbW9kX2V4ZXdlYi9hcmNoaXZlL3JlZnMvaGVhZHMvMzUtZGlmZmVyZW50LWxpdGVyYWwtaW4tZXhld2ViLWFuZC1leGVzY29ybS1wbHVnaW4uemlwIn0seyJzdGVwIjoic2V0Q29uZmlncyIsImNvbmZpZ3MiOlt7Im5hbWUiOiJlZGl0b3Jtb2RlIiwidmFsdWUiOiJlbWJlZGRlZCIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6ImRpc3BsYXlvcHRpb25zIiwidmFsdWUiOiIxLDUsNiIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6ImRpc3BsYXkiLCJ2YWx1ZSI6IjEiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJmcmFtZXNpemUiLCJ2YWx1ZSI6IjEzMCIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InByaW50aW50cm8iLCJ2YWx1ZSI6IjEiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJzaG93ZGF0ZSIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InBvcHVwd2lkdGgiLCJ2YWx1ZSI6IjYyMCIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InBvcHVwaGVpZ2h0IiwidmFsdWUiOiI0NTAiLCJwbHVnaW4iOiJleGV3ZWIifV19LHsic3RlcCI6ImNyZWF0ZUNhdGVnb3J5IiwibmFtZSI6IlRlc3QgQ291cnNlcyJ9LHsic3RlcCI6ImNyZWF0ZUNvdXJzZSIsImZ1bGxuYW1lIjoiZVhlTGVhcm5pbmcgV2ViIFRlc3QgQ291cnNlIiwic2hvcnRuYW1lIjoiRVhFV0VCMDEiLCJjYXRlZ29yeSI6IlRlc3QgQ291cnNlcyIsInN1bW1hcnkiOiJUZXN0IGNvdXJzZSBmb3IgdGhlIGVYZUxlYXJuaW5nIFdlYiBwbHVnaW4uIn0seyJzdGVwIjoiY3JlYXRlVXNlciIsInVzZXJuYW1lIjoic3R1ZGVudCIsInBhc3N3b3JkIjoicGFzc3dvcmQiLCJlbWFpbCI6InN0dWRlbnRAZXhhbXBsZS5jb20iLCJmaXJzdG5hbWUiOiJEZW1vIiwibGFzdG5hbWUiOiJTdHVkZW50In0seyJzdGVwIjoiZW5yb2xVc2VyIiwidXNlcm5hbWUiOiJ7e0FETUlOX1VTRVJ9fSIsImNvdXJzZSI6IkVYRVdFQjAxIiwicm9sZSI6ImVkaXRpbmd0ZWFjaGVyIn0seyJzdGVwIjoiZW5yb2xVc2VyIiwidXNlcm5hbWUiOiJzdHVkZW50IiwiY291cnNlIjoiRVhFV0VCMDEiLCJyb2xlIjoic3R1ZGVudCJ9LHsic3RlcCI6ImNyZWF0ZVNlY3Rpb24iLCJjb3Vyc2UiOiJFWEVXRUIwMSIsIm5hbWUiOiJFeGFtcGxlIFdlYiBBY3Rpdml0aWVzIn0seyJzdGVwIjoiYWRkTW9kdWxlIiwibW9kdWxlIjoiZXhld2ViIiwiY291cnNlIjoiRVhFV0VCMDEiLCJzZWN0aW9uIjoxLCJuYW1lIjoiVGVzdCBDb250ZW50IiwiaW50cm8iOiJTYW1wbGUgZVhlTGVhcm5pbmcgd2ViIGNvbnRlbnQgZm9yIHRlc3RpbmcuIiwiZXhlb3JpZ2luIjoibG9jYWwiLCJyZXZpc2lvbiI6MSwiZGlzcGxheSI6MSwiZmlsZXMiOlt7ImZpbGVhcmVhIjoicGFja2FnZSIsIml0ZW1pZCI6MSwiZmlsZW5hbWUiOiJ0ZXN0LWNvbnRlbnQuZWxweCIsImRhdGEiOnsidXJsIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2V4ZWxlYXJuaW5nL3dwLWV4ZWxlYXJuaW5nL3JlZnMvaGVhZHMvbWFpbi90ZXN0cy9maXh0dXJlcy90ZXN0LWNvbnRlbnQuZWxweCJ9fV19LHsic3RlcCI6ImFkZE1vZHVsZSIsIm1vZHVsZSI6ImV4ZXdlYiIsImNvdXJzZSI6IkVYRVdFQjAxIiwic2VjdGlvbiI6MSwibmFtZSI6IlByb3BpZWRhZGVzIiwiaW50cm8iOiJFeGFtcGxlIGNvbnRlbnQgZGVtb25zdHJhdGluZyBlWGVMZWFybmluZyBwcm9wZXJ0aWVzLiIsImV4ZW9yaWdpbiI6ImxvY2FsIiwicmV2aXNpb24iOjEsImRpc3BsYXkiOjEsImZpbGVzIjpbeyJmaWxlYXJlYSI6InBhY2thZ2UiLCJpdGVtaWQiOjEsImZpbGVuYW1lIjoicHJvcGllZGFkZXMuZWxweCIsImRhdGEiOnsidXJsIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2V4ZWxlYXJuaW5nL3dwLWV4ZWxlYXJuaW5nL3JlZnMvaGVhZHMvbWFpbi90ZXN0cy9maXh0dXJlcy9wcm9waWVkYWRlcy5lbHB4In19XX0seyJzdGVwIjoic2V0TGFuZGluZ1BhZ2UiLCJwYXRoIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIn1dfQ==" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

⚠️ The embedded eXeLearning editor is not included in this preview. You can install it from **Modules > eXeLearning Web > Configure** using the "Download & Install Editor" button. All other module features (ELPX upload, viewer, preview) work normally.
<!-- moodle-playground-preview:end -->