### PR TITLE
fix(set_ode): refresh entry file metadata on the new revision after online package replacement

### DIFF
--- a/set_ode.php
+++ b/set_ode.php
@@ -143,24 +143,42 @@ if (!empty($errors)) {
     echo json_encode($resultmsg);
     exit(1);
 }
-// Package is valid so delete files from package area and move the new one.
-$fs->delete_area_files($context->id, 'mod_exeweb', 'package');
-$exeweb->revision++;
-$fileinfo['itemid'] = $exeweb->revision;
+// Store the new package on a fresh revision before touching the previous one.
+// Old package and content files are deleted only after the new revision is in place,
+// so the activity remains consistent if extraction fails midway.
+$newrevision = (int)$exeweb->revision + 1;
+$fileinfo['itemid'] = $newrevision;
 $fileinfo['filearea'] = 'package';
 $package = $fs->create_file_from_storedfile($fileinfo, $tmpfile);
 $fs->delete_area_files($context->id, 'mod_exeweb', 'temppackage');
-// Process package contents.
+
+// Process package contents. expand_package() deletes content files for ALL itemids
+// before extracting the new ones into $package->get_itemid(), keeping the file area clean.
 $contentslist = exeweb_package::expand_package($package);
-$mainfile = exeweb_package::get_mainfile($contentslist, $package->get_contextid());
+// Pass $package->get_itemid() so get_mainfile() searches in the new revision.
+// Without it the lookup defaulted to itemid 0 and the entry file was never refreshed,
+// which left the activity pointing to outdated entrypath/entryname after each online save.
+$mainfile = exeweb_package::get_mainfile($contentslist, $package->get_contextid(), $package->get_itemid());
 if ($mainfile !== false) {
     file_set_sortorder($mainfile->get_contextid(), 'mod_exeweb', 'content',
-        $exeweb->revision, $mainfile->get_filepath(), $mainfile->get_filename(), 1);
-    $data->entrypath = $mainfile->get_filepath();
-    $data->entryname = $mainfile->get_filename();
+        $newrevision, $mainfile->get_filepath(), $mainfile->get_filename(), 1);
+    $exeweb->entrypath = $mainfile->get_filepath();
+    $exeweb->entryname = $mainfile->get_filename();
 }
 
+// Persist the new revision and entry file metadata together.
+$exeweb->revision = $newrevision;
+$exeweb->timemodified = time();
+$exeweb->usermodified = $user->id;
 $DB->update_record('exeweb', $exeweb);
+
+// Delete leftover package files from previous revisions only after success.
+$packagefiles = $fs->get_area_files($context->id, 'mod_exeweb', 'package', false, 'itemid', false);
+foreach ($packagefiles as $storedfile) {
+    if ((int)$storedfile->get_itemid() !== $newrevision) {
+        $storedfile->delete();
+    }
+}
 
 // Prepare OK response.
 $resultmsg['status'] = '0';

--- a/tests/exeweb_package_test.php
+++ b/tests/exeweb_package_test.php
@@ -1,0 +1,176 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for mod_exeweb package handling.
+ *
+ * Covers the regression behind issue #42 where webzip packages received from
+ * eXeLearning Online were extracted into the right itemid but
+ * {@see exeweb_package::get_mainfile()} was queried with the default itemid
+ * (0), leaving entrypath/entryname stale and breaking image references on the
+ * served HTML page.
+ *
+ * @package    mod_exeweb
+ * @copyright  2026 eXeLearning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace mod_exeweb;
+
+/**
+ * Unit tests for {@see exeweb_package}.
+ */
+final class exeweb_package_test extends \advanced_testcase {
+
+    /**
+     * Build an in-memory zip mimicking the layout produced by Html5Exporter
+     * when eXeLearning Online sends a webzip back to mod_exeweb. The structure
+     * matches what the editor generates: index.html at the root, an asset
+     * inside content/resources/, and a content.xml descriptor (the only file
+     * the validation rules require by default).
+     *
+     * @return string Raw zip contents.
+     */
+    private function build_webzip_contents(): string {
+        $tempzip = tempnam(make_request_directory(), 'exeweb_test_');
+        $zip = new \ZipArchive();
+        $zip->open($tempzip, \ZipArchive::OVERWRITE);
+        $zip->addFromString('index.html', '<!doctype html><html><body><img src="content/resources/photo.png"></body></html>');
+        $zip->addFromString('content/resources/photo.png', "PNG\x89\x50\x4e\x47\r\n\x1a\nFAKE");
+        $zip->addFromString('content.xml', '<?xml version="1.0"?><package />');
+        $zip->close();
+
+        $bytes = file_get_contents($tempzip);
+        @unlink($tempzip);
+
+        return $bytes;
+    }
+
+    /**
+     * Store a synthetic webzip in the package filearea at the requested itemid
+     * and return the resulting stored_file. Mirrors the relevant portion of
+     * set_ode.php so the test exercises the same Moodle file API calls.
+     *
+     * @param int $contextid
+     * @param int $itemid
+     * @return \stored_file
+     */
+    private function store_package_file(int $contextid, int $itemid): \stored_file {
+        $fs = get_file_storage();
+        $fileinfo = [
+            'contextid' => $contextid,
+            'component' => 'mod_exeweb',
+            'filearea' => 'package',
+            'itemid' => $itemid,
+            'filepath' => '/',
+            'filename' => 'package.zip',
+        ];
+        return $fs->create_file_from_string($fileinfo, $this->build_webzip_contents());
+    }
+
+    /**
+     * Regression test: get_mainfile() must locate index.html in the same
+     * itemid where expand_package() extracted the contents. The default
+     * itemid 0 used by the previous implementation silently missed the entry
+     * file when the package was stored on a non-zero revision (the case for
+     * every online save after the first one).
+     *
+     * @covers \mod_exeweb\exeweb_package::expand_package
+     * @covers \mod_exeweb\exeweb_package::get_mainfile
+     */
+    public function test_get_mainfile_uses_package_itemid(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course();
+        $exeweb = $this->getDataGenerator()->create_module('exeweb', ['course' => $course->id]);
+        $context = \context_module::instance($exeweb->cmid);
+
+        // Simulate an online save landing on revision 3 (the regression
+        // scenario reported in issue #42).
+        $itemid = 3;
+        $package = $this->store_package_file($context->id, $itemid);
+
+        $contentslist = exeweb_package::expand_package($package);
+        $this->assertNotEmpty($contentslist, 'expand_package must return the extracted file list');
+
+        $mainfile = exeweb_package::get_mainfile($contentslist, $context->id, $itemid);
+        $this->assertNotFalse($mainfile, 'get_mainfile must locate index.html when given the correct itemid');
+        $this->assertSame('index.html', $mainfile->get_filename());
+        $this->assertSame('/', $mainfile->get_filepath());
+
+        // Default-argument behaviour exposes the bug: index.html lives at
+        // itemid 3, but a call without itemid hits the default 0 and returns
+        // false.
+        $missingmainfile = exeweb_package::get_mainfile($contentslist, $context->id);
+        $this->assertFalse($missingmainfile,
+            'A call without the itemid argument must miss the entry file (regression for issue #42)');
+    }
+
+    /**
+     * Verify that the package extraction places nested resources in the same
+     * relative path that the HTML file references. This mirrors the URL the
+     * Moodle pluginfile handler builds when serving the activity, so a hit
+     * here implies the served page can resolve its assets.
+     *
+     * @covers \mod_exeweb\exeweb_package::expand_package
+     */
+    public function test_expand_package_preserves_resource_paths(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course();
+        $exeweb = $this->getDataGenerator()->create_module('exeweb', ['course' => $course->id]);
+        $context = \context_module::instance($exeweb->cmid);
+
+        $itemid = 5;
+        $package = $this->store_package_file($context->id, $itemid);
+
+        exeweb_package::expand_package($package);
+
+        $fs = get_file_storage();
+        $resource = $fs->get_file($context->id, 'mod_exeweb', 'content', $itemid,
+            '/content/resources/', 'photo.png');
+        $this->assertNotFalse($resource,
+            'Resources referenced by HTML must extract to the same path within the content filearea');
+    }
+
+    /**
+     * Calling expand_package() twice with two different revisions reflects an
+     * online save flow. After the second call only files for the latest
+     * revision remain in the content filearea, matching the URL the activity
+     * view will request.
+     *
+     * @covers \mod_exeweb\exeweb_package::expand_package
+     */
+    public function test_expand_package_replaces_old_revisions(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course();
+        $exeweb = $this->getDataGenerator()->create_module('exeweb', ['course' => $course->id]);
+        $context = \context_module::instance($exeweb->cmid);
+
+        $firstpackage = $this->store_package_file($context->id, 1);
+        exeweb_package::expand_package($firstpackage);
+
+        $secondpackage = $this->store_package_file($context->id, 2);
+        exeweb_package::expand_package($secondpackage);
+
+        $fs = get_file_storage();
+        $previous = $fs->get_area_files($context->id, 'mod_exeweb', 'content', 1, '', false);
+        $this->assertEmpty($previous, 'Stale content from previous revisions must be cleaned up');
+
+        $current = $fs->get_area_files($context->id, 'mod_exeweb', 'content', 2, '', false);
+        $this->assertNotEmpty($current, 'Latest revision must hold the freshly extracted files');
+    }
+}


### PR DESCRIPTION
## Summary

Complements exelearning/exelearning#1740 (which fixes the visible 404 on `content/resources/<uuid>.png` by generating the webzip in the browser). This PR fixes a separate Moodle-side consistency bug surfaced while investigating mod_exeweb#42: after the first online save, `entrypath`, `entryname` and the entry file `sortorder` kept pointing at the previous revision.

## Root cause

`set_ode.php` extracted the new package into `$exeweb->revision` but called `exeweb_package::get_mainfile()` without an `$itemid`. The default `itemid = 0` always missed the freshly extracted files, so:

- `entrypath` / `entryname` were never refreshed after the first online save.
- `file_set_sortorder()` was a no-op for the entry file.
- The activity kept pointing at the previous revision's metadata, while content lived under the new revision.

The embedded editor flow (`editor/save.php`) already passes the right itemid, which is why embedded mode works. The bug is specific to the online (set_ode.php) entry point.

## Changes

- `set_ode.php`
  - Pass `$package->get_itemid()` to `get_mainfile()` so the entry file is detected on the new revision.
  - Persist the new revision plus `entrypath` / `entryname` / `timemodified` / `usermodified` in a single `update_record()` call.
  - Defer cleanup of leftover package files until the new revision is fully in place. If anything between the validation and the DB update fails, the previous revision is still recoverable.

- `tests/exeweb_package_test.php` (new)
  - Regression test exercising `expand_package()` + `get_mainfile()` against a non-zero itemid (the actual case for every online save after the first).
  - Demonstrates that calling `get_mainfile()` without an itemid silently returns false (the regression behind this issue).
  - Verifies that resources extracted from the package end up at the path the served HTML references, and that re-running `expand_package()` cleans up stale revisions.

## Relationship to mod_exeweb#42

The 404 on `content/resources/<uuid>.png` reported in #42 is fixed on the eXeLearning side by exelearning/exelearning#1740 — the webzip is now generated in the browser (where the live Y.Doc and IndexedDB asset blobs are), and `BaseExporter.addAssetsToZipWithResourcePath` also writes each asset under its `<assetId><ext>` literal path so any stale `content/resources/<uuid>.<ext>` reference still resolves.

This PR does **not** make that symptom go away on its own. It addresses a separate, real consistency bug in Moodle: keeping the activity's entry-file bookkeeping in sync after every online save so `entrypath` / `entryname` / `revision` don't drift, and so the legacy server-side webzip fallback path doesn't keep stale references either.

Refs: mod_exeweb#42, exelearning/exelearning#1740

## Test plan

- [ ] `composer test` (full PHPUnit suite under the bundled Moodle docker image).
- [ ] Manual: create an exeweb activity (default template), edit it via eXeLearning Online, save back, refresh the activity in Moodle and confirm `entrypath` / `entryname` reflect the new package and the entry file is served correctly.

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgV2ViIERlbW8iLCJsb2NhbGUiOiJlcyIsInRpbWV6b25lIjoiRXVyb3BlL01hZHJpZCJ9fSx7InN0ZXAiOiJsb2dpbiIsInVzZXJuYW1lIjoie3tBRE1JTl9VU0VSfX0ifSx7InN0ZXAiOiJpbnN0YWxsTW9vZGxlUGx1Z2luIiwicGx1Z2luVHlwZSI6Im1vZCIsInBsdWdpbk5hbWUiOiJleGV3ZWIiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vZXhlbGVhcm5pbmcvbW9kX2V4ZXdlYi9hcmNoaXZlL3JlZnMvaGVhZHMvZml4L2lzc3VlLTQyLW9ubGluZS1pbWFnZS1wYXRocy56aXAifSx7InN0ZXAiOiJzZXRDb25maWdzIiwiY29uZmlncyI6W3sibmFtZSI6ImVkaXRvcm1vZGUiLCJ2YWx1ZSI6ImVtYmVkZGVkIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZGlzcGxheW9wdGlvbnMiLCJ2YWx1ZSI6IjEsNSw2IiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZGlzcGxheSIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6ImZyYW1lc2l6ZSIsInZhbHVlIjoiMTMwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicHJpbnRpbnRybyIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InNob3dkYXRlIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicG9wdXB3aWR0aCIsInZhbHVlIjoiNjIwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicG9wdXBoZWlnaHQiLCJ2YWx1ZSI6IjQ1MCIsInBsdWdpbiI6ImV4ZXdlYiJ9XX0seyJzdGVwIjoiY3JlYXRlQ2F0ZWdvcnkiLCJuYW1lIjoiVGVzdCBDb3Vyc2VzIn0seyJzdGVwIjoiY3JlYXRlQ291cnNlIiwiZnVsbG5hbWUiOiJlWGVMZWFybmluZyBXZWIgVGVzdCBDb3Vyc2UiLCJzaG9ydG5hbWUiOiJFWEVXRUIwMSIsImNhdGVnb3J5IjoiVGVzdCBDb3Vyc2VzIiwic3VtbWFyeSI6IlRlc3QgY291cnNlIGZvciB0aGUgZVhlTGVhcm5pbmcgV2ViIHBsdWdpbi4ifSx7InN0ZXAiOiJjcmVhdGVVc2VyIiwidXNlcm5hbWUiOiJzdHVkZW50IiwicGFzc3dvcmQiOiJwYXNzd29yZCIsImVtYWlsIjoic3R1ZGVudEBleGFtcGxlLmNvbSIsImZpcnN0bmFtZSI6IkRlbW8iLCJsYXN0bmFtZSI6IlN0dWRlbnQifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6Int7QURNSU5fVVNFUn19IiwiY291cnNlIjoiRVhFV0VCMDEiLCJyb2xlIjoiZWRpdGluZ3RlYWNoZXIifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6InN0dWRlbnQiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInJvbGUiOiJzdHVkZW50In0seyJzdGVwIjoiY3JlYXRlU2VjdGlvbiIsImNvdXJzZSI6IkVYRVdFQjAxIiwibmFtZSI6IkV4YW1wbGUgV2ViIEFjdGl2aXRpZXMifSx7InN0ZXAiOiJhZGRNb2R1bGUiLCJtb2R1bGUiOiJleGV3ZWIiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJUZXN0IENvbnRlbnQiLCJpbnRybyI6IlNhbXBsZSBlWGVMZWFybmluZyB3ZWIgY29udGVudCBmb3IgdGVzdGluZy4iLCJleGVvcmlnaW4iOiJsb2NhbCIsInJldmlzaW9uIjoxLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiaXRlbWlkIjoxLCJmaWxlbmFtZSI6InRlc3QtY29udGVudC5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Rlc3QtY29udGVudC5lbHB4In19XX0seyJzdGVwIjoiYWRkTW9kdWxlIiwibW9kdWxlIjoiZXhld2ViIiwiY291cnNlIjoiRVhFV0VCMDEiLCJzZWN0aW9uIjoxLCJuYW1lIjoiUHJvcGllZGFkZXMiLCJpbnRybyI6IkV4YW1wbGUgY29udGVudCBkZW1vbnN0cmF0aW5nIGVYZUxlYXJuaW5nIHByb3BlcnRpZXMuIiwiZXhlb3JpZ2luIjoibG9jYWwiLCJyZXZpc2lvbiI6MSwiZGlzcGxheSI6MSwiZmlsZXMiOlt7ImZpbGVhcmVhIjoicGFja2FnZSIsIml0ZW1pZCI6MSwiZmlsZW5hbWUiOiJwcm9waWVkYWRlcy5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Byb3BpZWRhZGVzLmVscHgifX1dfSx7InN0ZXAiOiJzZXRMYW5kaW5nUGFnZSIsInBhdGgiOiIvY291cnNlL3ZpZXcucGhwP2lkPTIifV19" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

⚠️ The embedded eXeLearning editor is not included in this preview. You can install it from **Modules > eXeLearning Web > Configure** using the "Download & Install Editor" button. All other module features (ELPX upload, viewer, preview) work normally.
<!-- moodle-playground-preview:end -->
