### PR TITLE
fix: stop shipping dev artefacts in make package ZIP (#50)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,9 +2,13 @@
 .github
 .gitignore
 .aider*
+.claude
 .DS_Store
 .distignore
+.editor-version
 .env
+.env.dist
+.omc
 exelearning/
 vendor/
 node_modules/
@@ -19,4 +23,5 @@ composer.phar
 CLAUDE.md
 AGENTS.md
 scripts/
+NUL
 mod_exeweb-*.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,3 +119,15 @@ Uses Moodle's file API — packages stored in `mod_exeweb/package` filearea, exp
 - `make package RELEASE=X.Y.Z` updates `version.php`, creates ZIP excluding files in `.distignore`, then restores dev values
 - GitHub Actions `release.yml` triggers on git tags: fetches editor, builds, packages, uploads to GitHub Release
 - `check-editor-releases.yml` runs daily to auto-release when new editor versions appear
+
+## Twin-plugin checks (mod_exeweb ↔ mod_exescorm)
+
+`mod_exeweb` and [`mod_exescorm`](https://github.com/exelearning/mod_exescorm) share large amounts of code, history, and bug surface (embedded editor, action bar, packaging pipeline, online callbacks, etc.). **Before closing a fix, always cross-check the sibling plugin:**
+
+1. **Search the sibling repo for a matching issue.** Examples:
+   - `gh issue list --repo exelearning/mod_exescorm --search "<keywords>"`
+   - `gh issue list --repo exelearning/mod_exescorm --state all --search "<keywords>"` (also closed)
+   If a matching issue exists, plan to fix both at once and link them in the PR bodies.
+2. **Even if no twin issue is open**, audit the sibling for the same root cause: most bugs reproduce on both sides because the relevant code is intentionally near-identical.
+3. When the bug applies to both, **open a PR in each repo** with the parallel fix and **cross-reference the sibling PR** in the body (e.g. `Sibling PR: exelearning/mod_exescorm#65`). Use parallel branch names and commit messages so the diffs are easy to compare.
+4. If after auditing only one plugin is affected, document why in the PR body so a future reader doesn't repeat the search.


### PR DESCRIPTION
## Summary
Fixes exelearning/exelearning#2092.

`.claude/`, `.omc/`, `.editor-version`, `.env.dist` and the stray Windows `NUL` file were being copied into the release ZIP because they were not listed in `.distignore`. They are now excluded so `make package RELEASE=X.Y.Z` produces a clean distribution.

`AGENTS.md` also gains a *Twin-plugin checks* section that asks coding agents to verify whether the same bug reproduces on [`mod_exescorm`](https://github.com/exelearning/mod_exescorm) and to open a sibling PR when it does — that is what motivated the parallel fix below.

### What changed
- `.distignore`: added `.claude`, `.omc`, `.editor-version`, `.env.dist`, `NUL`.
- `AGENTS.md`: new *Twin-plugin checks (mod_exeweb ↔ mod_exescorm)* section under *Packaging & Release*.

## Test plan
- [x] `make package RELEASE=test` produces `mod_exeweb-test.zip`; `unzip -l` shows no `.claude`, `.omc`, `.editor-version`, `.env*`, `NUL`, `.distignore`, or `.git*` entries.
- [x] The expected payload (`amd/`, `classes/`, `lang/`, `dist/`, `lib.php`, `view.php`, …) is still present and the ZIP installs cleanly via Moodle plugin install.

## Sibling PR
Same fix on the SCORM side: exelearning/mod_exescorm#67 (issue exelearning/exelearning#2100).

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgV2ViIERlbW8iLCJsb2NhbGUiOiJlcyIsInRpbWV6b25lIjoiRXVyb3BlL01hZHJpZCJ9fSx7InN0ZXAiOiJsb2dpbiIsInVzZXJuYW1lIjoie3tBRE1JTl9VU0VSfX0ifSx7InN0ZXAiOiJpbnN0YWxsTW9vZGxlUGx1Z2luIiwicGx1Z2luVHlwZSI6Im1vZCIsInBsdWdpbk5hbWUiOiJleGV3ZWIiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vZXhlbGVhcm5pbmcvbW9kX2V4ZXdlYi9hcmNoaXZlL3JlZnMvaGVhZHMvNTAtbm8tdW5uZWNlc3NhcnktZmlsZXMtaW4tcGFja2FnZS56aXAifSx7InN0ZXAiOiJzZXRDb25maWdzIiwiY29uZmlncyI6W3sibmFtZSI6ImVkaXRvcm1vZGUiLCJ2YWx1ZSI6ImVtYmVkZGVkIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZGlzcGxheW9wdGlvbnMiLCJ2YWx1ZSI6IjEsNSw2IiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZGlzcGxheSIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6ImZyYW1lc2l6ZSIsInZhbHVlIjoiMTMwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicHJpbnRpbnRybyIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InNob3dkYXRlIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicG9wdXB3aWR0aCIsInZhbHVlIjoiNjIwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicG9wdXBoZWlnaHQiLCJ2YWx1ZSI6IjQ1MCIsInBsdWdpbiI6ImV4ZXdlYiJ9XX0seyJzdGVwIjoiY3JlYXRlQ2F0ZWdvcnkiLCJuYW1lIjoiVGVzdCBDb3Vyc2VzIn0seyJzdGVwIjoiY3JlYXRlQ291cnNlIiwiZnVsbG5hbWUiOiJlWGVMZWFybmluZyBXZWIgVGVzdCBDb3Vyc2UiLCJzaG9ydG5hbWUiOiJFWEVXRUIwMSIsImNhdGVnb3J5IjoiVGVzdCBDb3Vyc2VzIiwic3VtbWFyeSI6IlRlc3QgY291cnNlIGZvciB0aGUgZVhlTGVhcm5pbmcgV2ViIHBsdWdpbi4ifSx7InN0ZXAiOiJjcmVhdGVVc2VyIiwidXNlcm5hbWUiOiJzdHVkZW50IiwicGFzc3dvcmQiOiJwYXNzd29yZCIsImVtYWlsIjoic3R1ZGVudEBleGFtcGxlLmNvbSIsImZpcnN0bmFtZSI6IkRlbW8iLCJsYXN0bmFtZSI6IlN0dWRlbnQifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6Int7QURNSU5fVVNFUn19IiwiY291cnNlIjoiRVhFV0VCMDEiLCJyb2xlIjoiZWRpdGluZ3RlYWNoZXIifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6InN0dWRlbnQiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInJvbGUiOiJzdHVkZW50In0seyJzdGVwIjoiY3JlYXRlU2VjdGlvbiIsImNvdXJzZSI6IkVYRVdFQjAxIiwibmFtZSI6IkV4YW1wbGUgV2ViIEFjdGl2aXRpZXMifSx7InN0ZXAiOiJhZGRNb2R1bGUiLCJtb2R1bGUiOiJleGV3ZWIiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJUZXN0IENvbnRlbnQiLCJpbnRybyI6IlNhbXBsZSBlWGVMZWFybmluZyB3ZWIgY29udGVudCBmb3IgdGVzdGluZy4iLCJleGVvcmlnaW4iOiJsb2NhbCIsInJldmlzaW9uIjoxLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiaXRlbWlkIjoxLCJmaWxlbmFtZSI6InRlc3QtY29udGVudC5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Rlc3QtY29udGVudC5lbHB4In19XX0seyJzdGVwIjoiYWRkTW9kdWxlIiwibW9kdWxlIjoiZXhld2ViIiwiY291cnNlIjoiRVhFV0VCMDEiLCJzZWN0aW9uIjoxLCJuYW1lIjoiUHJvcGllZGFkZXMiLCJpbnRybyI6IkV4YW1wbGUgY29udGVudCBkZW1vbnN0cmF0aW5nIGVYZUxlYXJuaW5nIHByb3BlcnRpZXMuIiwiZXhlb3JpZ2luIjoibG9jYWwiLCJyZXZpc2lvbiI6MSwiZGlzcGxheSI6MSwiZmlsZXMiOlt7ImZpbGVhcmVhIjoicGFja2FnZSIsIml0ZW1pZCI6MSwiZmlsZW5hbWUiOiJwcm9waWVkYWRlcy5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Byb3BpZWRhZGVzLmVscHgifX1dfSx7InN0ZXAiOiJzZXRMYW5kaW5nUGFnZSIsInBhdGgiOiIvY291cnNlL3ZpZXcucGhwP2lkPTIifV19" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

⚠️ The embedded eXeLearning editor is not included in this preview. You can install it from **Modules > eXeLearning Web > Configure** using the "Download & Install Editor" button. All other module features (ELPX upload, viewer, preview) work normally.
<!-- moodle-playground-preview:end -->