### PR TITLE
fix: stop upgradesettings.php loop on styles upload widget (#47)

### DIFF
--- a/classes/admin/admin_setting_stylesupload.php
+++ b/classes/admin/admin_setting_stylesupload.php
@@ -57,6 +57,28 @@ class admin_setting_stylesupload extends \admin_setting_configstoredfile {
     public const FILEAREA = 'styles_drops';
 
     /**
+     * Report a non-null stored value so this setting is never flagged as
+     * "new" on `admin/upgradesettings.php`.
+     *
+     * `admin_setting_configstoredfile` reads the file id from plugin config,
+     * but our `write_setting()` deletes the staged ZIP after extraction and
+     * never persists anything in `config_plugins`. Without this override,
+     * `get_setting()` keeps returning `null`, so Moodle's
+     * `admin_output_new_settings_by_page()` re-renders the upload widget on
+     * every plugin upgrade, trapping the admin in an upgrade-settings loop
+     * (issues #47 / #51).
+     *
+     * The widget itself does not need a stored value to render — it always
+     * starts from a fresh draft area — so returning an empty string is
+     * functionally equivalent to "nothing pending".
+     *
+     * @return string
+     */
+    public function get_setting() {
+        return '';
+    }
+
+    /**
      * Stage any uploaded drafts into the plugin filearea and extract them.
      *
      * We bypass `admin_setting_configstoredfile::write_setting()` because


### PR DESCRIPTION
## Summary
Fixes exelearning/mod_exescorm#47 (and the duplicate exelearning/exelearning#2093).

After upgrading to v4.0.0, every admin login was being redirected to `admin/upgradesettings.php` with the *Styles upload* widget shown as a "new setting" — and clicking **Save changes** never cleared it, even when a style was selected.

### Root cause
`admin_setting_stylesupload` extends `admin_setting_configstoredfile`, whose `get_setting()` reads the stored file id from plugin config. Our `write_setting()` extracts the uploaded ZIP and immediately deletes it, so nothing is ever persisted in `config_plugins`. As a result, `get_setting()` always returned `null`. Moodle's `admin_output_new_settings_by_page()` (in `lib/adminlib.php`, line 9231) flags any setting whose `get_setting()` is null as new, so the upload widget reappeared on every visit and the admin was trapped in the loop.

### Fix
Override `get_setting()` in `admin_setting_stylesupload` to return an empty string. The widget itself does not need a stored value — it always starts from a fresh draft area — so this is functionally equivalent to "nothing pending" while telling Moodle the setting has been seen. `write_setting()` keeps behaving exactly as before.

This mirrors the pattern already used in `admin_setting_embeddededitor` (the embedded-editor management widget), which solved the same problem the same way.

## Test plan
- [x] Fresh install of plugin: visit `/admin/upgradesettings.php?return=admin` — the *Style packages (.zip)* row no longer appears as a new setting.
- [x] Click **Save changes** in the regular plugin settings page (Modules > eXeLearning Web): the form saves cleanly and does not bounce back to upgradesettings.
- [x] Drop a style ZIP, save: the ZIP is extracted and the upload widget shows the new entry under *Uploaded styles*.
- [x] Drop a second time: install errors are still surfaced via `\core\notification`.

## Sibling PR
Same fix on the SCORM side: exelearning/mod_exescorm#68 (issue exelearning/exelearning#2101).

Closes exelearning/mod_exescorm#47. Closes exelearning/exelearning#2093 as duplicate.