### PR TITLE
fix: embed final editor version when packaging

### DIFF
--- a/.github/workflows/check-editor-releases.yml
+++ b/.github/workflows/check-editor-releases.yml
@@ -57,6 +57,8 @@ jobs:
           EXELEARNING_EDITOR_REPO_URL: https://github.com/exelearning/exelearning.git
           EXELEARNING_EDITOR_REF: ${{ steps.check.outputs.tag }}
           EXELEARNING_EDITOR_REF_TYPE: tag
+          # Embed the final release version in the editor build (not 0.0.0-alpha).
+          APP_VERSION: ${{ steps.check.outputs.tag }}
         run: make build-editor
 
       - name: Compute version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,10 @@ jobs:
             VERSION_TAG="${RAW_TAG#v}"
             echo "RELEASE_TAG=${VERSION_TAG}" >> $GITHUB_ENV
             echo "EXELEARNING_EDITOR_REPO_URL=https://github.com/exelearning/exelearning.git" >> $GITHUB_ENV
-            echo "EXELEARNING_EDITOR_REF=main" >> $GITHUB_ENV
-            echo "EXELEARNING_EDITOR_REF_TYPE=branch" >> $GITHUB_ENV
+            # Build the editor from the matching editor tag so the embedded
+            # editor reports the final release version (not a nightly/alpha build).
+            echo "EXELEARNING_EDITOR_REF=v${VERSION_TAG}" >> $GITHUB_ENV
+            echo "EXELEARNING_EDITOR_REF_TYPE=tag" >> $GITHUB_ENV
           else
             INPUT_RELEASE="${{ github.event.inputs.release_tag }}"
             if [ -z "$INPUT_RELEASE" ]; then

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,24 @@ fetch-editor-source:
 
 # Build static editor to dist/static/
 build-editor: check-bun fetch-editor-source
-	cd $(EDITOR_SUBMODULE_PATH) && bun install && bun run build:static
+	@# Resolve the version to embed in the editor build. The editor's build script
+	@# (scripts/build-static-bundle.ts) reads APP_VERSION/VERSION; without it the
+	@# build falls back to package.json (0.0.0-alpha). Resolution order:
+	@#   APP_VERSION -> VERSION -> EXELEARNING_EDITOR_REF (env or .env) ->
+	@#   exact git tag of the checked-out editor -> empty (dev default -> alpha)
+	@set -e; \
+	get_env() { \
+		if [ -f .env ]; then \
+			grep -E "^$$1=" .env | tail -n1 | cut -d '=' -f2-; \
+		fi; \
+	}; \
+	APP_VER="$${APP_VERSION:-$${VERSION:-$${EXELEARNING_EDITOR_REF:-$$(get_env EXELEARNING_EDITOR_REF)}}}"; \
+	if [ -z "$$APP_VER" ] || [ "$$APP_VER" = "main" ] || [ "$$APP_VER" = "master" ]; then \
+		EXACT_TAG="$$(git -C $(EDITOR_SUBMODULE_PATH) describe --tags --exact-match 2>/dev/null || true)"; \
+		if [ -n "$$EXACT_TAG" ]; then APP_VER="$$EXACT_TAG"; fi; \
+	fi; \
+	echo "Editor version input: $${APP_VER:-(default -> alpha)}"; \
+	cd $(EDITOR_SUBMODULE_PATH) && bun install && APP_VERSION="$$APP_VER" bun run build:static
 	@mkdir -p $(EDITOR_DIST_PATH)
 	@rm -rf $(EDITOR_DIST_PATH)/*
 	cp -r $(EDITOR_SUBMODULE_PATH)/dist/static/* $(EDITOR_DIST_PATH)/


### PR DESCRIPTION
Same root cause and fix as exelearning/exelearning#2044.

## Problem

When packaging a release, the embedded eXeLearning editor reports `v0.0.0-alpha` instead of the final editor version (e.g. `v4.0.0`). The bundled `dist/static/data/bundle.json` and `dist/static/manifest.json` show `v0.0.0-alpha`.

## Root cause

`exelearning/scripts/build-static-bundle.ts` resolves the version only from `--version=` / `VERSION` / `APP_VERSION`, and otherwise falls back to `v${packageJson.version}` = `0.0.0-alpha`. It does **not** derive the version from the git tag.

The `build-editor` target in the `Makefile` ran `bun run build:static` **without passing any of those variables**, so it always produced `0.0.0-alpha`. In addition, `release.yml` built the editor from `main` instead of the matching tag.

## Changes

- **`Makefile`** (`build-editor`): resolves `APP_VERSION` (order: `APP_VERSION` → `VERSION` → `EXELEARNING_EDITOR_REF` env/`.env` → exact git tag of the editor checkout → empty for local dev) and passes it to `build:static`.
- **`.github/workflows/release.yml`**: on the `release` event, builds the editor from the matching editor tag (`vX.Y.Z`) instead of `main`.
- **`.github/workflows/check-editor-releases.yml`**: passes `APP_VERSION` explicitly.

## Verification

```
EXELEARNING_EDITOR_REF=v4.0.0 EXELEARNING_EDITOR_REF_TYPE=tag make build-editor
# [Version] Input: v4.0.0 (APP_VERSION env) → Output: v4.0.0
grep '"version"' dist/static/data/bundle.json   # → "version": "v4.0.0"
grep name dist/static/manifest.json             # → "eXeLearning Editor (v4.0.0)"
```

Local build without variables (dev) still works with its alpha/nightly fallback.

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgV2ViIERlbW8iLCJsb2NhbGUiOiJlcyIsInRpbWV6b25lIjoiRXVyb3BlL01hZHJpZCJ9fSx7InN0ZXAiOiJsb2dpbiIsInVzZXJuYW1lIjoie3tBRE1JTl9VU0VSfX0ifSx7InN0ZXAiOiJpbnN0YWxsTW9vZGxlUGx1Z2luIiwicGx1Z2luVHlwZSI6Im1vZCIsInBsdWdpbk5hbWUiOiJleGV3ZWIiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vZXhlbGVhcm5pbmcvbW9kX2V4ZXdlYi9hcmNoaXZlL3JlZnMvaGVhZHMvZml4L2VtYmVkLWVkaXRvci12ZXJzaW9uLnppcCJ9LHsic3RlcCI6InNldENvbmZpZ3MiLCJjb25maWdzIjpbeyJuYW1lIjoiZWRpdG9ybW9kZSIsInZhbHVlIjoiZW1iZWRkZWQiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJkaXNwbGF5b3B0aW9ucyIsInZhbHVlIjoiMSw1LDYiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJkaXNwbGF5IiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZnJhbWVzaXplIiwidmFsdWUiOiIxMzAiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJwcmludGludHJvIiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoic2hvd2RhdGUiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJwb3B1cHdpZHRoIiwidmFsdWUiOiI2MjAiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJwb3B1cGhlaWdodCIsInZhbHVlIjoiNDUwIiwicGx1Z2luIjoiZXhld2ViIn1dfSx7InN0ZXAiOiJjcmVhdGVDYXRlZ29yeSIsIm5hbWUiOiJUZXN0IENvdXJzZXMifSx7InN0ZXAiOiJjcmVhdGVDb3Vyc2UiLCJmdWxsbmFtZSI6ImVYZUxlYXJuaW5nIFdlYiBUZXN0IENvdXJzZSIsInNob3J0bmFtZSI6IkVYRVdFQjAxIiwiY2F0ZWdvcnkiOiJUZXN0IENvdXJzZXMiLCJzdW1tYXJ5IjoiVGVzdCBjb3Vyc2UgZm9yIHRoZSBlWGVMZWFybmluZyBXZWIgcGx1Z2luLiJ9LHsic3RlcCI6ImNyZWF0ZVVzZXIiLCJ1c2VybmFtZSI6InN0dWRlbnQiLCJwYXNzd29yZCI6InBhc3N3b3JkIiwiZW1haWwiOiJzdHVkZW50QGV4YW1wbGUuY29tIiwiZmlyc3RuYW1lIjoiRGVtbyIsImxhc3RuYW1lIjoiU3R1ZGVudCJ9LHsic3RlcCI6ImVucm9sVXNlciIsInVzZXJuYW1lIjoie3tBRE1JTl9VU0VSfX0iLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInJvbGUiOiJlZGl0aW5ndGVhY2hlciJ9LHsic3RlcCI6ImVucm9sVXNlciIsInVzZXJuYW1lIjoic3R1ZGVudCIsImNvdXJzZSI6IkVYRVdFQjAxIiwicm9sZSI6InN0dWRlbnQifSx7InN0ZXAiOiJjcmVhdGVTZWN0aW9uIiwiY291cnNlIjoiRVhFV0VCMDEiLCJuYW1lIjoiRXhhbXBsZSBXZWIgQWN0aXZpdGllcyJ9LHsic3RlcCI6ImFkZE1vZHVsZSIsIm1vZHVsZSI6ImV4ZXdlYiIsImNvdXJzZSI6IkVYRVdFQjAxIiwic2VjdGlvbiI6MSwibmFtZSI6IlRlc3QgQ29udGVudCIsImludHJvIjoiU2FtcGxlIGVYZUxlYXJuaW5nIHdlYiBjb250ZW50IGZvciB0ZXN0aW5nLiIsImV4ZW9yaWdpbiI6ImxvY2FsIiwicmV2aXNpb24iOjEsImRpc3BsYXkiOjEsImZpbGVzIjpbeyJmaWxlYXJlYSI6InBhY2thZ2UiLCJpdGVtaWQiOjEsImZpbGVuYW1lIjoidGVzdC1jb250ZW50LmVscHgiLCJkYXRhIjp7InVybCI6Imh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS9leGVsZWFybmluZy93cC1leGVsZWFybmluZy9yZWZzL2hlYWRzL21haW4vdGVzdHMvZml4dHVyZXMvdGVzdC1jb250ZW50LmVscHgifX1dfSx7InN0ZXAiOiJhZGRNb2R1bGUiLCJtb2R1bGUiOiJleGV3ZWIiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJQcm9waWVkYWRlcyIsImludHJvIjoiRXhhbXBsZSBjb250ZW50IGRlbW9uc3RyYXRpbmcgZVhlTGVhcm5pbmcgcHJvcGVydGllcy4iLCJleGVvcmlnaW4iOiJsb2NhbCIsInJldmlzaW9uIjoxLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiaXRlbWlkIjoxLCJmaWxlbmFtZSI6InByb3BpZWRhZGVzLmVscHgiLCJkYXRhIjp7InVybCI6Imh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS9leGVsZWFybmluZy93cC1leGVsZWFybmluZy9yZWZzL2hlYWRzL21haW4vdGVzdHMvZml4dHVyZXMvcHJvcGllZGFkZXMuZWxweCJ9fV19LHsic3RlcCI6InNldExhbmRpbmdQYWdlIiwicGF0aCI6Ii9jb3Vyc2Uvdmlldy5waHA_aWQ9MiJ9XX0" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

⚠️ The embedded eXeLearning editor is not included in this preview. You can install it from **Modules > eXeLearning Web > Configure** using the "Download & Install Editor" button. All other module features (ELPX upload, viewer, preview) work normally.
<!-- moodle-playground-preview:end -->