### PR TITLE
feat(playground): auto-load the editor via a blueprint unzip step

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -38,7 +38,7 @@ jobs:
           mode: append-to-description
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-text: >
-            ⚠️ The embedded eXeLearning editor is not included in this preview.
-            You can install it from **Modules > eXeLearning Web > Configure**
-            using the "Download & Install Editor" button.
-            All other module features (ELPX upload, viewer, preview) work normally.
+            ℹ️ The eXeLearning editor is fetched from the shared release and
+            unpacked into the plugin when the playground boots, so the first
+            load may take a few extra seconds. ELPX upload, viewer and preview
+            work normally.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # eXeLearning web sites for Moodle
 
-[![Preview in Moodle Playground](https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg)](https://moodle-playground.com/?blueprint-url=https://raw.githubusercontent.com/exelearning/mod_exeweb/refs/heads/main/blueprint.json)
+<a href="https://moodle-playground.com/?blueprint-url=https://raw.githubusercontent.com/exelearning/mod_exeweb/refs/heads/main/blueprint.json"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="224"></a>
+
+> ℹ️ The eXeLearning editor is fetched from the shared release and unpacked into the plugin when the playground boots, so the first load may take a few extra seconds. ELPX upload, viewer and preview work normally.
 
 Activity-type module to create and edit web sites with eXeLearning inside Moodle.
 

--- a/blueprint.json
+++ b/blueprint.json
@@ -27,6 +27,12 @@
       "url": "https://github.com/exelearning/mod_exeweb/archive/refs/heads/main.zip"
     },
     {
+      "step": "unzip",
+      "comment": "Auto-load the eXeLearning static editor so the playground boots with a working editor. Fetches the shared editor release asset once through the github-proxy (CORS) and extracts it into the plugin's bundled dir. The asset wraps everything in a 'static/' folder, so extracting into 'dist' yields 'dist/static/...', which embedded_editor_source_resolver serves via its 'bundled' precedence (moodledata -> bundled -> none). Pinned to match .editor-version for deterministic previews. embedded_editor_installer stays for production/offline installs.",
+      "destination": "/www/moodle/mod/exeweb/dist",
+      "data": { "url": "https://github-proxy.exelearning.dev/?repo=exelearning/exelearning&release=v4.0.0&asset=exelearning-static-v4.0.0.zip" }
+    },
+    {
       "step": "setConfigs",
       "configs": [
         { "name": "editormode", "value": "embedded", "plugin": "exeweb" },


### PR DESCRIPTION
## What

Auto-load the embedded eXeLearning editor in the Playground via a single `unzip` blueprint step, so it boots with a working editor instead of requiring the manual **Download & Install Editor** button.

```json
{
  "step": "unzip",
  "destination": "/www/moodle/mod/exeweb/dist",
  "data": { "url": "https://github-proxy.exelearning.dev/?repo=exelearning/exelearning&release=v4.0.0&asset=exelearning-static-v4.0.0.zip" }
}
```

## Why

The static editor is byte-identical across all eXeLearning plugins and is already published once at `exelearning/exelearning`. Fetching that shared artifact through the github-proxy (CORS) over the **fast JS transport** is the WordPress-Playground-idiomatic pattern and avoids both a per-PR built artifact and the slow runtime PHP download. The release asset wraps everything in a `static/` folder, so extracting into `dist` yields `dist/static/...`, which `embedded_editor_source_resolver` serves via its `bundled` precedence (`moodledata -> bundled -> none`). Pinned to `v4.0.0` to match `.editor-version` for deterministic previews.

`embedded_editor_installer` is **kept** for production/offline installs; only the playground changes.

> Part of a fleet-wide change unifying how the editor loads in every eXeLearning playground.

## Test

Open the Playground for this branch and confirm the editor loads on boot (no manual step), the editor zip is fetched from `github-proxy.exelearning.dev`, and a page renders.

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgV2ViIERlbW8iLCJsb2NhbGUiOiJlcyIsInRpbWV6b25lIjoiRXVyb3BlL01hZHJpZCJ9fSx7InN0ZXAiOiJsb2dpbiIsInVzZXJuYW1lIjoie3tBRE1JTl9VU0VSfX0ifSx7InN0ZXAiOiJpbnN0YWxsTW9vZGxlUGx1Z2luIiwicGx1Z2luVHlwZSI6Im1vZCIsInBsdWdpbk5hbWUiOiJleGV3ZWIiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vZXhlbGVhcm5pbmcvbW9kX2V4ZXdlYi9hcmNoaXZlL3JlZnMvaGVhZHMvZmVhdC9wbGF5Z3JvdW5kLWVkaXRvci11bnppcC56aXAifSx7InN0ZXAiOiJ1bnppcCIsImNvbW1lbnQiOiJBdXRvLWxvYWQgdGhlIGVYZUxlYXJuaW5nIHN0YXRpYyBlZGl0b3Igc28gdGhlIHBsYXlncm91bmQgYm9vdHMgd2l0aCBhIHdvcmtpbmcgZWRpdG9yLiBGZXRjaGVzIHRoZSBzaGFyZWQgZWRpdG9yIHJlbGVhc2UgYXNzZXQgb25jZSB0aHJvdWdoIHRoZSBnaXRodWItcHJveHkgKENPUlMpIGFuZCBleHRyYWN0cyBpdCBpbnRvIHRoZSBwbHVnaW4ncyBidW5kbGVkIGRpci4gVGhlIGFzc2V0IHdyYXBzIGV2ZXJ5dGhpbmcgaW4gYSAnc3RhdGljLycgZm9sZGVyLCBzbyBleHRyYWN0aW5nIGludG8gJ2Rpc3QnIHlpZWxkcyAnZGlzdC9zdGF0aWMvLi4uJywgd2hpY2ggZW1iZWRkZWRfZWRpdG9yX3NvdXJjZV9yZXNvbHZlciBzZXJ2ZXMgdmlhIGl0cyAnYnVuZGxlZCcgcHJlY2VkZW5jZSAobW9vZGxlZGF0YSAtPiBidW5kbGVkIC0-IG5vbmUpLiBQaW5uZWQgdG8gbWF0Y2ggLmVkaXRvci12ZXJzaW9uIGZvciBkZXRlcm1pbmlzdGljIHByZXZpZXdzLiBlbWJlZGRlZF9lZGl0b3JfaW5zdGFsbGVyIHN0YXlzIGZvciBwcm9kdWN0aW9uL29mZmxpbmUgaW5zdGFsbHMuIiwiZGVzdGluYXRpb24iOiIvd3d3L21vb2RsZS9tb2QvZXhld2ViL2Rpc3QiLCJkYXRhIjp7InVybCI6Imh0dHBzOi8vZ2l0aHViLXByb3h5LmV4ZWxlYXJuaW5nLmRldi8_cmVwbz1leGVsZWFybmluZy9leGVsZWFybmluZyZyZWxlYXNlPXY0LjAuMCZhc3NldD1leGVsZWFybmluZy1zdGF0aWMtdjQuMC4wLnppcCJ9fSx7InN0ZXAiOiJzZXRDb25maWdzIiwiY29uZmlncyI6W3sibmFtZSI6ImVkaXRvcm1vZGUiLCJ2YWx1ZSI6ImVtYmVkZGVkIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZGlzcGxheW9wdGlvbnMiLCJ2YWx1ZSI6IjEsNSw2IiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZGlzcGxheSIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6ImZyYW1lc2l6ZSIsInZhbHVlIjoiMTMwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicHJpbnRpbnRybyIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InNob3dkYXRlIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicG9wdXB3aWR0aCIsInZhbHVlIjoiNjIwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicG9wdXBoZWlnaHQiLCJ2YWx1ZSI6IjQ1MCIsInBsdWdpbiI6ImV4ZXdlYiJ9XX0seyJzdGVwIjoiY3JlYXRlQ2F0ZWdvcnkiLCJuYW1lIjoiVGVzdCBDb3Vyc2VzIn0seyJzdGVwIjoiY3JlYXRlQ291cnNlIiwiZnVsbG5hbWUiOiJlWGVMZWFybmluZyBXZWIgVGVzdCBDb3Vyc2UiLCJzaG9ydG5hbWUiOiJFWEVXRUIwMSIsImNhdGVnb3J5IjoiVGVzdCBDb3Vyc2VzIiwic3VtbWFyeSI6IlRlc3QgY291cnNlIGZvciB0aGUgZVhlTGVhcm5pbmcgV2ViIHBsdWdpbi4ifSx7InN0ZXAiOiJjcmVhdGVVc2VyIiwidXNlcm5hbWUiOiJzdHVkZW50IiwicGFzc3dvcmQiOiJwYXNzd29yZCIsImVtYWlsIjoic3R1ZGVudEBleGFtcGxlLmNvbSIsImZpcnN0bmFtZSI6IkRlbW8iLCJsYXN0bmFtZSI6IlN0dWRlbnQifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6Int7QURNSU5fVVNFUn19IiwiY291cnNlIjoiRVhFV0VCMDEiLCJyb2xlIjoiZWRpdGluZ3RlYWNoZXIifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6InN0dWRlbnQiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInJvbGUiOiJzdHVkZW50In0seyJzdGVwIjoiY3JlYXRlU2VjdGlvbiIsImNvdXJzZSI6IkVYRVdFQjAxIiwibmFtZSI6IkV4YW1wbGUgV2ViIEFjdGl2aXRpZXMifSx7InN0ZXAiOiJhZGRNb2R1bGUiLCJtb2R1bGUiOiJleGV3ZWIiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJUZXN0IENvbnRlbnQiLCJpbnRybyI6IlNhbXBsZSBlWGVMZWFybmluZyB3ZWIgY29udGVudCBmb3IgdGVzdGluZy4iLCJleGVvcmlnaW4iOiJsb2NhbCIsInJldmlzaW9uIjoxLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiaXRlbWlkIjoxLCJmaWxlbmFtZSI6InRlc3QtY29udGVudC5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Rlc3QtY29udGVudC5lbHB4In19XX0seyJzdGVwIjoiYWRkTW9kdWxlIiwibW9kdWxlIjoiZXhld2ViIiwiY291cnNlIjoiRVhFV0VCMDEiLCJzZWN0aW9uIjoxLCJuYW1lIjoiUHJvcGllZGFkZXMiLCJpbnRybyI6IkV4YW1wbGUgY29udGVudCBkZW1vbnN0cmF0aW5nIGVYZUxlYXJuaW5nIHByb3BlcnRpZXMuIiwiZXhlb3JpZ2luIjoibG9jYWwiLCJyZXZpc2lvbiI6MSwiZGlzcGxheSI6MSwiZmlsZXMiOlt7ImZpbGVhcmVhIjoicGFja2FnZSIsIml0ZW1pZCI6MSwiZmlsZW5hbWUiOiJwcm9waWVkYWRlcy5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Byb3BpZWRhZGVzLmVscHgifX1dfSx7InN0ZXAiOiJzZXRMYW5kaW5nUGFnZSIsInBhdGgiOiIvY291cnNlL3ZpZXcucGhwP2lkPTIifV19" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

ℹ️ The eXeLearning editor is fetched from the shared release and unpacked into the plugin when the playground boots, so the first load may take a few extra seconds. ELPX upload, viewer and preview work normally.
<!-- moodle-playground-preview:end -->