### PR TITLE
fix(playground): keep blueprint editor version in sync with .editor-version

### DIFF
--- a/.github/workflows/check-editor-releases.yml
+++ b/.github/workflows/check-editor-releases.yml
@@ -77,11 +77,19 @@ jobs:
       - name: Update editor version marker
         if: steps.check.outputs.found == 'true'
         run: |
-          echo "${{ steps.check.outputs.tag }}" > .editor-version
+          TAG="${{ steps.check.outputs.tag }}"
+          echo "$TAG" > .editor-version
+          # Keep the playground blueprint's editor URL in sync with .editor-version,
+          # otherwise the preview stays pinned to the hardcoded version.
+          sed -i -E \
+            -e "s#(release=)v[0-9][0-9A-Za-z.-]*#\1$TAG#g" \
+            -e "s#(releases/download/)v[0-9][0-9A-Za-z.-]*#\1$TAG#g" \
+            -e "s#(exelearning-static-)v[0-9][0-9A-Za-z.-]*(\.zip)#\1$TAG\2#g" \
+            blueprint.json
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .editor-version
-          git commit -m "Update editor version to ${{ steps.check.outputs.tag }}"
+          git add .editor-version blueprint.json
+          git commit -m "Update editor version to $TAG"
           git push
 
       - name: Create GitHub Release

--- a/blueprint.json
+++ b/blueprint.json
@@ -30,7 +30,7 @@
       "step": "unzip",
       "comment": "Auto-load the eXeLearning static editor so the playground boots with a working editor. Fetches the shared editor release asset once through the github-proxy (CORS) and extracts it into the plugin's bundled dir. The asset wraps everything in a 'static/' folder, so extracting into 'dist' yields 'dist/static/...', which embedded_editor_source_resolver serves via its 'bundled' precedence (moodledata -> bundled -> none). Pinned to match .editor-version for deterministic previews. embedded_editor_installer stays for production/offline installs.",
       "destination": "/www/moodle/mod/exeweb/dist",
-      "data": { "url": "https://github-proxy.exelearning.dev/?repo=exelearning/exelearning&release=v4.0.0&asset=exelearning-static-v4.0.0.zip" }
+      "data": { "url": "https://github-proxy.exelearning.dev/?repo=exelearning/exelearning&release=v4.0.1&asset=exelearning-static-v4.0.1.zip" }
     },
     {
       "step": "setConfigs",


### PR DESCRIPTION
## Problem

The playground booted with eXeLearning editor **v4.0.0** even though the latest upstream release — and this repo's `.editor-version` — is **v4.0.1**.

Root cause: there are two sources of truth for the editor version, and only one was kept current.

- `.editor-version` — bumped automatically every day by `check-editor-releases.yml`.
- `blueprint.json` — a **hardcoded** editor download URL that the workflow never touched.

So `.editor-version` advanced to v4.0.1 while `blueprint.json` stayed pinned at v4.0.0, and the playground / PR-preview kept serving the old editor. Production plugin releases were unaffected (they bake the editor from `.editor-version`); only the playground demo drifted.

## Fix

- **Catch-up:** bump the editor URL in `blueprint.json` to v4.0.1 so it matches `.editor-version`.
- **Durable:** `check-editor-releases.yml` now rewrites the blueprint's editor URL (via `sed`) whenever it bumps `.editor-version`, and commits both files together, so they can never drift apart again.

The `sed` only rewrites the editor asset reference (`release=`, `releases/download/`, `exelearning-static-*.zip`); the plugin source URL and content fixtures are left untouched. Verified against plain version tags and RC-suffixed tags (e.g. `v4.0.0-rc3`).

## Verification

- `blueprint.json` now resolves the same version as `.editor-version` (v4.0.1).
- Dry-run of the workflow `sed` rewrites only the editor URL on a simulated bump.
- `blueprint.json` is valid JSON and the workflow is valid YAML.

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgV2ViIERlbW8iLCJsb2NhbGUiOiJlcyIsInRpbWV6b25lIjoiRXVyb3BlL01hZHJpZCJ9fSx7InN0ZXAiOiJsb2dpbiIsInVzZXJuYW1lIjoie3tBRE1JTl9VU0VSfX0ifSx7InN0ZXAiOiJpbnN0YWxsTW9vZGxlUGx1Z2luIiwicGx1Z2luVHlwZSI6Im1vZCIsInBsdWdpbk5hbWUiOiJleGV3ZWIiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vZXhlbGVhcm5pbmcvbW9kX2V4ZXdlYi9hcmNoaXZlL3JlZnMvaGVhZHMvZml4L3BsYXlncm91bmQtZWRpdG9yLXZlcnNpb24tc3luYy56aXAifSx7InN0ZXAiOiJ1bnppcCIsImNvbW1lbnQiOiJBdXRvLWxvYWQgdGhlIGVYZUxlYXJuaW5nIHN0YXRpYyBlZGl0b3Igc28gdGhlIHBsYXlncm91bmQgYm9vdHMgd2l0aCBhIHdvcmtpbmcgZWRpdG9yLiBGZXRjaGVzIHRoZSBzaGFyZWQgZWRpdG9yIHJlbGVhc2UgYXNzZXQgb25jZSB0aHJvdWdoIHRoZSBnaXRodWItcHJveHkgKENPUlMpIGFuZCBleHRyYWN0cyBpdCBpbnRvIHRoZSBwbHVnaW4ncyBidW5kbGVkIGRpci4gVGhlIGFzc2V0IHdyYXBzIGV2ZXJ5dGhpbmcgaW4gYSAnc3RhdGljLycgZm9sZGVyLCBzbyBleHRyYWN0aW5nIGludG8gJ2Rpc3QnIHlpZWxkcyAnZGlzdC9zdGF0aWMvLi4uJywgd2hpY2ggZW1iZWRkZWRfZWRpdG9yX3NvdXJjZV9yZXNvbHZlciBzZXJ2ZXMgdmlhIGl0cyAnYnVuZGxlZCcgcHJlY2VkZW5jZSAobW9vZGxlZGF0YSAtPiBidW5kbGVkIC0-IG5vbmUpLiBQaW5uZWQgdG8gbWF0Y2ggLmVkaXRvci12ZXJzaW9uIGZvciBkZXRlcm1pbmlzdGljIHByZXZpZXdzLiBlbWJlZGRlZF9lZGl0b3JfaW5zdGFsbGVyIHN0YXlzIGZvciBwcm9kdWN0aW9uL29mZmxpbmUgaW5zdGFsbHMuIiwiZGVzdGluYXRpb24iOiIvd3d3L21vb2RsZS9tb2QvZXhld2ViL2Rpc3QiLCJkYXRhIjp7InVybCI6Imh0dHBzOi8vZ2l0aHViLXByb3h5LmV4ZWxlYXJuaW5nLmRldi8_cmVwbz1leGVsZWFybmluZy9leGVsZWFybmluZyZyZWxlYXNlPXY0LjAuMSZhc3NldD1leGVsZWFybmluZy1zdGF0aWMtdjQuMC4xLnppcCJ9fSx7InN0ZXAiOiJzZXRDb25maWdzIiwiY29uZmlncyI6W3sibmFtZSI6ImVkaXRvcm1vZGUiLCJ2YWx1ZSI6ImVtYmVkZGVkIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZGlzcGxheW9wdGlvbnMiLCJ2YWx1ZSI6IjEsNSw2IiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoiZGlzcGxheSIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6ImZyYW1lc2l6ZSIsInZhbHVlIjoiMTMwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicHJpbnRpbnRybyIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InNob3dkYXRlIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicG9wdXB3aWR0aCIsInZhbHVlIjoiNjIwIiwicGx1Z2luIjoiZXhld2ViIn0seyJuYW1lIjoicG9wdXBoZWlnaHQiLCJ2YWx1ZSI6IjQ1MCIsInBsdWdpbiI6ImV4ZXdlYiJ9XX0seyJzdGVwIjoiY3JlYXRlQ2F0ZWdvcnkiLCJuYW1lIjoiVGVzdCBDb3Vyc2VzIn0seyJzdGVwIjoiY3JlYXRlQ291cnNlIiwiZnVsbG5hbWUiOiJlWGVMZWFybmluZyBXZWIgVGVzdCBDb3Vyc2UiLCJzaG9ydG5hbWUiOiJFWEVXRUIwMSIsImNhdGVnb3J5IjoiVGVzdCBDb3Vyc2VzIiwic3VtbWFyeSI6IlRlc3QgY291cnNlIGZvciB0aGUgZVhlTGVhcm5pbmcgV2ViIHBsdWdpbi4ifSx7InN0ZXAiOiJjcmVhdGVVc2VyIiwidXNlcm5hbWUiOiJzdHVkZW50IiwicGFzc3dvcmQiOiJwYXNzd29yZCIsImVtYWlsIjoic3R1ZGVudEBleGFtcGxlLmNvbSIsImZpcnN0bmFtZSI6IkRlbW8iLCJsYXN0bmFtZSI6IlN0dWRlbnQifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6Int7QURNSU5fVVNFUn19IiwiY291cnNlIjoiRVhFV0VCMDEiLCJyb2xlIjoiZWRpdGluZ3RlYWNoZXIifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6InN0dWRlbnQiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInJvbGUiOiJzdHVkZW50In0seyJzdGVwIjoiY3JlYXRlU2VjdGlvbiIsImNvdXJzZSI6IkVYRVdFQjAxIiwibmFtZSI6IkV4YW1wbGUgV2ViIEFjdGl2aXRpZXMifSx7InN0ZXAiOiJhZGRNb2R1bGUiLCJtb2R1bGUiOiJleGV3ZWIiLCJjb3Vyc2UiOiJFWEVXRUIwMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJUZXN0IENvbnRlbnQiLCJpbnRybyI6IlNhbXBsZSBlWGVMZWFybmluZyB3ZWIgY29udGVudCBmb3IgdGVzdGluZy4iLCJleGVvcmlnaW4iOiJsb2NhbCIsInJldmlzaW9uIjoxLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiaXRlbWlkIjoxLCJmaWxlbmFtZSI6InRlc3QtY29udGVudC5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Rlc3QtY29udGVudC5lbHB4In19XX0seyJzdGVwIjoiYWRkTW9kdWxlIiwibW9kdWxlIjoiZXhld2ViIiwiY291cnNlIjoiRVhFV0VCMDEiLCJzZWN0aW9uIjoxLCJuYW1lIjoiUHJvcGllZGFkZXMiLCJpbnRybyI6IkV4YW1wbGUgY29udGVudCBkZW1vbnN0cmF0aW5nIGVYZUxlYXJuaW5nIHByb3BlcnRpZXMuIiwiZXhlb3JpZ2luIjoibG9jYWwiLCJyZXZpc2lvbiI6MSwiZGlzcGxheSI6MSwiZmlsZXMiOlt7ImZpbGVhcmVhIjoicGFja2FnZSIsIml0ZW1pZCI6MSwiZmlsZW5hbWUiOiJwcm9waWVkYWRlcy5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Byb3BpZWRhZGVzLmVscHgifX1dfSx7InN0ZXAiOiJzZXRMYW5kaW5nUGFnZSIsInBhdGgiOiIvY291cnNlL3ZpZXcucGhwP2lkPTIifV19" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

ℹ️ The eXeLearning editor is fetched from the shared release and unpacked into the plugin when the playground boots, so the first load may take a few extra seconds. ELPX upload, viewer and preview work normally.
<!-- moodle-playground-preview:end -->