### PR TITLE
Fix optional template setting save without upload

### DIFF
--- a/classes/admin/admin_setting_optional_configstoredfile.php
+++ b/classes/admin/admin_setting_optional_configstoredfile.php
@@ -1,0 +1,113 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Optional variant of Moodle's stored-file admin setting.
+ *
+ * @package    mod_exeweb
+ * @copyright  2025 eXeLearning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_exeweb\admin;
+
+/**
+ * Optional stored-file admin setting that is safe to leave empty.
+ *
+ * Moodle flags an admin setting as "new" whenever its get_setting() returns
+ * null (see admin_output_new_settings_by_page() in lib/adminlib.php), which
+ * forces the administrator through the "New settings" upgrade page after a
+ * plugin upgrade. The stock admin_setting_configstoredfile keeps returning
+ * null until a file is stored, and its write_setting() rejects the save with
+ * an "errorsetting" message when the filemanager posts no draft item id. For
+ * an optional file (such as the package template) that combination traps the
+ * administrator on the "New settings" page unless they upload a file, even
+ * though no file is required (see issue #2000).
+ *
+ * This subclass keeps the normal stored-file behaviour for real uploads,
+ * replacements and intentional clears, but turns a "nothing submitted /
+ * nothing changed" save into a safe no-op that never deletes an already
+ * stored file and never leaves the configured value as null.
+ */
+class admin_setting_optional_configstoredfile extends \admin_setting_configstoredfile {
+    /** @var bool Whether the last write_setting() was a no-op over a stored file. */
+    private $nofilechange = false;
+
+    /**
+     * Return the stored value, substituting '' for null.
+     *
+     * Returning a non-null value stops admin_output_new_settings_by_page()
+     * from treating an empty optional file as a new/unconfigured setting on
+     * every upgrade. When a file is stored, the real config value (the stored
+     * file path) is returned unchanged so replace/clear detection and the
+     * filemanager rendering keep working as in core.
+     *
+     * @return string The stored file path, or '' when nothing is stored.
+     */
+    public function get_setting() {
+        $value = parent::get_setting();
+        return $value === null ? '' : $value;
+    }
+
+    /**
+     * Persist an uploaded file, or accept an empty submission as a no-op.
+     *
+     * @param mixed $data Draft item id submitted by the filemanager.
+     * @return string Empty string on success, or an error message on failure.
+     */
+    public function write_setting($data) {
+        // No usable draft item id: the filemanager was left untouched or its
+        // draft area was never initialised (issue #2000), or an empty value
+        // ('', null, '0', ...) was posted. Treat it as a successful no-op:
+        // never call file_save_draft_area_files() (it would delete an already
+        // stored file when handed an empty draft) and never return an error.
+        if (!is_number($data) || (int) $data <= 0) {
+            if ($this->get_setting() === '') {
+                // Nothing is stored: record an explicit empty value so the
+                // optional setting is not reported as new on the next upgrade.
+                $this->nofilechange = false;
+                return ($this->config_write($this->name, '') ? '' : get_string('errorsetting', 'admin'));
+            }
+            // A file is already stored: keep it untouched and report no change.
+            $this->nofilechange = true;
+            return '';
+        }
+
+        // A positive draft item id was submitted: defer to Moodle core, which
+        // saves uploaded files, honours an intentionally cleared filemanager
+        // and protects an existing file when the draft area is missing.
+        $this->nofilechange = false;
+        return parent::write_setting($data);
+    }
+
+    /**
+     * Report whether the stored file changed.
+     *
+     * The parent compares stored file hashes to detect a change. Our no-op
+     * branch deliberately skips that bookkeeping, so report "unchanged" here
+     * to avoid a spurious "changes saved" notification when an existing file
+     * was left untouched.
+     *
+     * @param mixed $original Value returned by get_setting() before the write.
+     * @return bool True when the stored file changed.
+     */
+    public function post_write_settings($original) {
+        if ($this->nofilechange) {
+            return false;
+        }
+        return parent::post_write_settings($original);
+    }
+}

--- a/settings.php
+++ b/settings.php
@@ -156,7 +156,7 @@ if ($ADMIN->fulltree) {
         'subdirs' => 0,
     ];
 
-    $settings->add(new admin_setting_configstoredfile('exeweb/template',
+    $settings->add(new \mod_exeweb\admin\admin_setting_optional_configstoredfile('exeweb/template',
         get_string('exeweb:template', 'mod_exeweb'),
         get_string('exeweb:template_desc', 'mod_exeweb'),
         'config', 0, $filemanageroptions

--- a/tests/admin/admin_setting_optional_configstoredfile_test.php
+++ b/tests/admin/admin_setting_optional_configstoredfile_test.php
@@ -1,0 +1,228 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for the optional stored-file admin setting.
+ *
+ * @package    mod_exeweb
+ * @copyright  2025 eXeLearning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_exeweb\admin;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/filelib.php');
+
+/**
+ * Regression tests covering the save flow of admin_setting_optional_configstoredfile.
+ *
+ * @covers \mod_exeweb\admin\admin_setting_optional_configstoredfile
+ */
+class admin_setting_optional_configstoredfile_test extends \advanced_testcase {
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+    }
+
+    /**
+     * Build the setting under test with the same options the plugin uses in
+     * its settings page.
+     *
+     * @return admin_setting_optional_configstoredfile
+     */
+    private function build_setting(): admin_setting_optional_configstoredfile {
+        return new admin_setting_optional_configstoredfile(
+            'exeweb/template',
+            'New package template',
+            'Optional package template.',
+            'config',
+            0,
+            [
+                'accepted_types' => ['.zip', '.elpx'],
+                'maxbytes' => 0,
+                'maxfiles' => 1,
+                'subdirs' => 0,
+            ]
+        );
+    }
+
+    /**
+     * Stage a file in a fresh user draft area and return its draft item id.
+     *
+     * @param string $filename Name of the file to stage.
+     * @param string $content Raw file contents.
+     * @return int Draft item id holding the staged file.
+     */
+    private function stage_template_file(string $filename, string $content): int {
+        global $USER;
+        $draftitemid = file_get_unused_draft_itemid();
+        $usercontext = \context_user::instance($USER->id);
+        get_file_storage()->create_file_from_string([
+            'contextid' => $usercontext->id,
+            'component' => 'user',
+            'filearea' => 'draft',
+            'itemid' => $draftitemid,
+            'filepath' => '/',
+            'filename' => $filename,
+        ], $content);
+        return $draftitemid;
+    }
+
+    /**
+     * Return the files stored in the plugin config filearea (excluding dirs).
+     *
+     * @return \stored_file[]
+     */
+    private function get_stored_files(): array {
+        $syscontext = \context_system::instance();
+        return get_file_storage()->get_area_files(
+            $syscontext->id,
+            'exeweb',
+            'config',
+            0,
+            'itemid, filepath, filename',
+            false
+        );
+    }
+
+    /**
+     * A fresh optional setting must report '' instead of null, so Moodle does
+     * not keep flagging it as a new setting on the upgrade page.
+     */
+    public function test_get_setting_returns_empty_string_for_fresh_setting(): void {
+        $setting = $this->build_setting();
+        $this->assertSame('', $setting->get_setting());
+    }
+
+    /**
+     * Saving with no draft item id ('', '0' or null) must succeed without
+     * error, store nothing, and persist an explicit (non-null) empty value.
+     */
+    public function test_write_setting_with_empty_values_returns_empty(): void {
+        $setting = $this->build_setting();
+        $this->assertSame('', $setting->write_setting(''));
+        $this->assertSame('', $setting->write_setting('0'));
+        $this->assertSame('', $setting->write_setting(null));
+        $this->assertCount(0, $this->get_stored_files());
+        // The persisted value must be '' (not null) so the setting is never
+        // treated as new on the upgrade page.
+        $this->assertSame('', get_config('exeweb', 'template'));
+    }
+
+    /**
+     * Saving with a valid but empty draft area (the widget was opened but no
+     * file attached) must still succeed and store nothing.
+     */
+    public function test_write_setting_with_empty_draft_returns_empty(): void {
+        $setting = $this->build_setting();
+        $draftitemid = file_get_unused_draft_itemid();
+        $this->assertSame('', $setting->write_setting((string) $draftitemid));
+        $this->assertCount(0, $this->get_stored_files());
+    }
+
+    /**
+     * Uploading a template must store exactly one file in the plugin config
+     * filearea and expose its path through get_setting().
+     */
+    public function test_write_setting_stores_uploaded_file(): void {
+        $setting = $this->build_setting();
+        $draftitemid = $this->stage_template_file('template.elpx', 'dummy package');
+
+        $this->assertSame('', $setting->write_setting((string) $draftitemid));
+
+        $files = $this->get_stored_files();
+        $this->assertCount(1, $files);
+        $file = reset($files);
+        $this->assertSame('template.elpx', $file->get_filename());
+        $this->assertSame('/template.elpx', $setting->get_setting());
+    }
+
+    /**
+     * Uploading a second file must replace the stored template, leaving
+     * exactly one file in the filearea.
+     */
+    public function test_write_setting_replaces_stored_file(): void {
+        $setting = $this->build_setting();
+        $setting->write_setting((string) $this->stage_template_file('template.elpx', 'first'));
+        $this->assertCount(1, $this->get_stored_files());
+
+        $setting->write_setting((string) $this->stage_template_file('template2.elpx', 'second'));
+
+        $files = $this->get_stored_files();
+        $this->assertCount(1, $files);
+        $file = reset($files);
+        $this->assertSame('template2.elpx', $file->get_filename());
+        $this->assertSame('/template2.elpx', $setting->get_setting());
+    }
+
+    /**
+     * Once a template is stored, a later save with no draft (the admin simply
+     * saves the settings page without touching the widget) must keep the file.
+     */
+    public function test_stored_file_is_preserved_on_empty_save(): void {
+        $setting = $this->build_setting();
+        $draftitemid = $this->stage_template_file('template.elpx', 'dummy package');
+        $setting->write_setting((string) $draftitemid);
+        $this->assertCount(1, $this->get_stored_files());
+
+        $this->assertSame('', $setting->write_setting(''));
+        $this->assertSame('', $setting->write_setting('0'));
+        $this->assertSame('', $setting->write_setting(null));
+
+        $this->assertCount(1, $this->get_stored_files());
+        $this->assertSame('/template.elpx', $setting->get_setting());
+    }
+
+    /**
+     * An empty save that leaves an existing file untouched must not be
+     * reported as a change by post_write_settings().
+     */
+    public function test_empty_save_over_stored_file_reports_no_change(): void {
+        $setting = $this->build_setting();
+        $setting->write_setting((string) $this->stage_template_file('template.elpx', 'dummy package'));
+
+        $original = $setting->get_setting();
+        $this->assertSame('', $setting->write_setting(''));
+        $this->assertFalse($setting->post_write_settings($original));
+    }
+
+    /**
+     * Intentionally clearing the filemanager (an existing but empty draft
+     * area) must remove the stored template.
+     */
+    public function test_intentional_clear_removes_stored_file(): void {
+        global $USER;
+        $setting = $this->build_setting();
+        $draftitemid = $this->stage_template_file('template.elpx', 'dummy package');
+        $setting->write_setting((string) $draftitemid);
+        $this->assertCount(1, $this->get_stored_files());
+
+        // Simulate the admin opening the filemanager and deleting the file:
+        // a draft area that exists but contains no files.
+        $cleardraftid = file_get_unused_draft_itemid();
+        $usercontext = \context_user::instance($USER->id);
+        get_file_storage()->create_directory($usercontext->id, 'user', 'draft', $cleardraftid, '/');
+
+        $this->assertSame('', $setting->write_setting((string) $cleardraftid));
+        $this->assertCount(0, $this->get_stored_files());
+        $this->assertSame('', $setting->get_setting());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the optional "New package template" admin setting so the settings page can be saved when no template file is uploaded or when the filemanager is left untouched.

## Problem

The template setting uses Moodle's `admin_setting_configstoredfile`. During the plugin upgrade / new-settings flow, Moodle treats the setting as new (`admin_output_new_settings_by_page()` flags any setting whose `get_setting()` is `null`) and the save can fail because `admin_setting_configstoredfile::write_setting()` returns an `errorsetting` when the filemanager posts no/empty `draftitemid` — even though the template is optional.

This blocks admins on the "New settings" page unless they upload a template file (issue exelearning/exelearning#2000).

## Changes

- Add a plugin-local optional stored-file admin setting class `\mod_exeweb\admin\admin_setting_optional_configstoredfile`.
- `get_setting()` reports `''` instead of `null` for an unset optional file, so it is never treated as a new/unconfigured setting.
- `write_setting()` accepts an empty/missing/`'0'`/non-positive draft as a successful no-op: it never calls `file_save_draft_area_files()` with an empty draft (which would delete an existing template) and never returns an error.
- Positive draft item ids are delegated to core, preserving the normal upload / replace / intentional-clear behaviour. File type restrictions (`['.zip', '.elpx']`) are unchanged.
- `post_write_settings()` reports "no change" for an untouched empty save, avoiding a spurious "changes saved" notice.
- Replace the `exeweb/template` setting with the new optional stored-file setting (one line in `settings.php`).
- Add PHPUnit regression tests for empty saves, empty drafts, uploads, replace, preserving existing files, intentional clear, and change detection.

## Testing

- [x] Moodle phpcs (`--standard=moodle`, moodle-cs 3.7.0) — clean on the new files
- [x] PHPUnit `mod/exeweb/tests/admin/admin_setting_optional_configstoredfile_test.php` — 8 tests, 28 assertions, OK (Moodle 5.0.5, PHPUnit 11.5)

Run in a Docker Moodle 5.0.5 environment (`erseco/alpine-moodle`).

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgV2ViIERlbW8iLCJsb2NhbGUiOiJlcyIsInRpbWV6b25lIjoiRXVyb3BlL01hZHJpZCJ9fSx7InN0ZXAiOiJsb2dpbiIsInVzZXJuYW1lIjoie3tBRE1JTl9VU0VSfX0ifSx7InN0ZXAiOiJpbnN0YWxsTW9vZGxlUGx1Z2luIiwicGx1Z2luVHlwZSI6Im1vZCIsInBsdWdpbk5hbWUiOiJleGV3ZWIiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vZXhlbGVhcm5pbmcvbW9kX2V4ZXdlYi9hcmNoaXZlL3JlZnMvaGVhZHMvZml4L29wdGlvbmFsLXRlbXBsYXRlLXNldHRpbmcuemlwIn0seyJzdGVwIjoidW56aXAiLCJjb21tZW50IjoiQXV0by1sb2FkIHRoZSBlWGVMZWFybmluZyBzdGF0aWMgZWRpdG9yIHNvIHRoZSBwbGF5Z3JvdW5kIGJvb3RzIHdpdGggYSB3b3JraW5nIGVkaXRvci4gRmV0Y2hlcyB0aGUgc2hhcmVkIGVkaXRvciByZWxlYXNlIGFzc2V0IG9uY2UgdGhyb3VnaCB0aGUgZ2l0aHViLXByb3h5IChDT1JTKSBhbmQgZXh0cmFjdHMgaXQgaW50byB0aGUgcGx1Z2luJ3MgYnVuZGxlZCBkaXIuIFRoZSBhc3NldCB3cmFwcyBldmVyeXRoaW5nIGluIGEgJ3N0YXRpYy8nIGZvbGRlciwgc28gZXh0cmFjdGluZyBpbnRvICdkaXN0JyB5aWVsZHMgJ2Rpc3Qvc3RhdGljLy4uLicsIHdoaWNoIGVtYmVkZGVkX2VkaXRvcl9zb3VyY2VfcmVzb2x2ZXIgc2VydmVzIHZpYSBpdHMgJ2J1bmRsZWQnIHByZWNlZGVuY2UgKG1vb2RsZWRhdGEgLT4gYnVuZGxlZCAtPiBub25lKS4gUGlubmVkIHRvIG1hdGNoIC5lZGl0b3ItdmVyc2lvbiBmb3IgZGV0ZXJtaW5pc3RpYyBwcmV2aWV3cy4gZW1iZWRkZWRfZWRpdG9yX2luc3RhbGxlciBzdGF5cyBmb3IgcHJvZHVjdGlvbi9vZmZsaW5lIGluc3RhbGxzLiIsImRlc3RpbmF0aW9uIjoiL3d3dy9tb29kbGUvbW9kL2V4ZXdlYi9kaXN0IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL2dpdGh1Yi1wcm94eS5leGVsZWFybmluZy5kZXYvP3JlcG89ZXhlbGVhcm5pbmcvZXhlbGVhcm5pbmcmcmVsZWFzZT12NC4wLjEmYXNzZXQ9ZXhlbGVhcm5pbmctc3RhdGljLXY0LjAuMS56aXAifX0seyJzdGVwIjoic2V0Q29uZmlncyIsImNvbmZpZ3MiOlt7Im5hbWUiOiJlZGl0b3Jtb2RlIiwidmFsdWUiOiJlbWJlZGRlZCIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6ImRpc3BsYXlvcHRpb25zIiwidmFsdWUiOiIxLDUsNiIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6ImRpc3BsYXkiLCJ2YWx1ZSI6IjEiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJmcmFtZXNpemUiLCJ2YWx1ZSI6IjEzMCIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InByaW50aW50cm8iLCJ2YWx1ZSI6IjEiLCJwbHVnaW4iOiJleGV3ZWIifSx7Im5hbWUiOiJzaG93ZGF0ZSIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InBvcHVwd2lkdGgiLCJ2YWx1ZSI6IjYyMCIsInBsdWdpbiI6ImV4ZXdlYiJ9LHsibmFtZSI6InBvcHVwaGVpZ2h0IiwidmFsdWUiOiI0NTAiLCJwbHVnaW4iOiJleGV3ZWIifV19LHsic3RlcCI6ImNyZWF0ZUNhdGVnb3J5IiwibmFtZSI6IlRlc3QgQ291cnNlcyJ9LHsic3RlcCI6ImNyZWF0ZUNvdXJzZSIsImZ1bGxuYW1lIjoiZVhlTGVhcm5pbmcgV2ViIFRlc3QgQ291cnNlIiwic2hvcnRuYW1lIjoiRVhFV0VCMDEiLCJjYXRlZ29yeSI6IlRlc3QgQ291cnNlcyIsInN1bW1hcnkiOiJUZXN0IGNvdXJzZSBmb3IgdGhlIGVYZUxlYXJuaW5nIFdlYiBwbHVnaW4uIn0seyJzdGVwIjoiY3JlYXRlVXNlciIsInVzZXJuYW1lIjoic3R1ZGVudCIsInBhc3N3b3JkIjoicGFzc3dvcmQiLCJlbWFpbCI6InN0dWRlbnRAZXhhbXBsZS5jb20iLCJmaXJzdG5hbWUiOiJEZW1vIiwibGFzdG5hbWUiOiJTdHVkZW50In0seyJzdGVwIjoiZW5yb2xVc2VyIiwidXNlcm5hbWUiOiJ7e0FETUlOX1VTRVJ9fSIsImNvdXJzZSI6IkVYRVdFQjAxIiwicm9sZSI6ImVkaXRpbmd0ZWFjaGVyIn0seyJzdGVwIjoiZW5yb2xVc2VyIiwidXNlcm5hbWUiOiJzdHVkZW50IiwiY291cnNlIjoiRVhFV0VCMDEiLCJyb2xlIjoic3R1ZGVudCJ9LHsic3RlcCI6ImNyZWF0ZVNlY3Rpb24iLCJjb3Vyc2UiOiJFWEVXRUIwMSIsIm5hbWUiOiJFeGFtcGxlIFdlYiBBY3Rpdml0aWVzIn0seyJzdGVwIjoiYWRkTW9kdWxlIiwibW9kdWxlIjoiZXhld2ViIiwiY291cnNlIjoiRVhFV0VCMDEiLCJzZWN0aW9uIjoxLCJuYW1lIjoiVGVzdCBDb250ZW50IiwiaW50cm8iOiJTYW1wbGUgZVhlTGVhcm5pbmcgd2ViIGNvbnRlbnQgZm9yIHRlc3RpbmcuIiwiZXhlb3JpZ2luIjoibG9jYWwiLCJyZXZpc2lvbiI6MSwiZGlzcGxheSI6MSwiZmlsZXMiOlt7ImZpbGVhcmVhIjoicGFja2FnZSIsIml0ZW1pZCI6MSwiZmlsZW5hbWUiOiJ0ZXN0LWNvbnRlbnQuZWxweCIsImRhdGEiOnsidXJsIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2V4ZWxlYXJuaW5nL3dwLWV4ZWxlYXJuaW5nL3JlZnMvaGVhZHMvbWFpbi90ZXN0cy9maXh0dXJlcy90ZXN0LWNvbnRlbnQuZWxweCJ9fV19LHsic3RlcCI6ImFkZE1vZHVsZSIsIm1vZHVsZSI6ImV4ZXdlYiIsImNvdXJzZSI6IkVYRVdFQjAxIiwic2VjdGlvbiI6MSwibmFtZSI6IlByb3BpZWRhZGVzIiwiaW50cm8iOiJFeGFtcGxlIGNvbnRlbnQgZGVtb25zdHJhdGluZyBlWGVMZWFybmluZyBwcm9wZXJ0aWVzLiIsImV4ZW9yaWdpbiI6ImxvY2FsIiwicmV2aXNpb24iOjEsImRpc3BsYXkiOjEsImZpbGVzIjpbeyJmaWxlYXJlYSI6InBhY2thZ2UiLCJpdGVtaWQiOjEsImZpbGVuYW1lIjoicHJvcGllZGFkZXMuZWxweCIsImRhdGEiOnsidXJsIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2V4ZWxlYXJuaW5nL3dwLWV4ZWxlYXJuaW5nL3JlZnMvaGVhZHMvbWFpbi90ZXN0cy9maXh0dXJlcy9wcm9waWVkYWRlcy5lbHB4In19XX0seyJzdGVwIjoic2V0TGFuZGluZ1BhZ2UiLCJwYXRoIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIn1dfQ" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

ℹ️ The eXeLearning editor is fetched from the shared release and unpacked into the plugin when the playground boots, so the first load may take a few extra seconds. ELPX upload, viewer and preview work normally.
<!-- moodle-playground-preview:end -->